### PR TITLE
fix: Fixed undefined property and invalid URL issue in credits generator

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ let extractLicense = (sourceLink, dep) => {
 }
 
 let extractBody = (rawLink, sourceLink, dep) => {
-  console.log('[Step 4] Extracting body for ' + rawLink)
+  console.log('[Step 3] Extracting body for ' + rawLink)
   c.queue({
     uri: rawLink,
     jQuery: false,
@@ -91,7 +91,7 @@ let extractBody = (rawLink, sourceLink, dep) => {
 }
 
 let writeToFile = (body, sourceLink, dep) => {
-  console.log('[Step 5] Writing to file for ' + dep)
+  console.log('[Step 4] Writing to file for ' + dep)
   let project = `\n## Project\n${dep}\n`
   let source = `\n### Source\n${sourceLink}\n`
   let license = `\n### License\n${body}\n\n`

--- a/index.js
+++ b/index.js
@@ -55,8 +55,10 @@ let extractLicense = (sourceLink, dep) => {
       let licenseElement = $('a[href*="LICENSE"]')
       if (licenseElement.length) {
         // License is in a LICENSE file
-        let licenseLink = 'https://github.com' + (licenseElement[0].attribs.href)
-        extractRaw(licenseLink, sourceLink, dep)
+        let path = licenseElement[0].attribs.href.replace('/blob', '')
+        let rawLink = 'https://raw.githubusercontent.com/' + path
+        extractBody(rawLink, sourceLink, dep)
+        done()
       } else {
         // Check if license is in the README
         let body = $('.Box-body').text()
@@ -69,20 +71,6 @@ let extractLicense = (sourceLink, dep) => {
         }
         writeToFile(licenseBody, sourceLink, dep)
       }
-      done()
-    },
-  })
-}
-
-let extractRaw = (licenseLink, sourceLink, dep) => {
-  console.log('[Step 3] Extracting raw for ' + licenseLink)
-  c.queue({
-    uri: licenseLink,
-    callback: function (err, res, done) {
-      if (err) throw err
-      let $ = res.$
-      let rawLink = 'https://github.com' + $('a[id="raw-url"]')[0].attribs.href
-      extractBody(rawLink, sourceLink, dep)
       done()
     },
   })


### PR DESCRIPTION
## Problem

Github has removed the raw-url link element. As such, the credit generator cannot obtain the URL to the raw license text file from the href attribute.

Closes FRM-1501

## Solution

Updated the license checker to create the raw URL from the license URL.

## Before & After Screenshots

**BEFORE**:
<img width="1423" alt="Screenshot 2023-11-02 at 6 35 08 PM" src="https://github.com/opengovsg/credits-generator/assets/136435307/509f01ac-e08a-4504-8f3a-d5fea58ce551">


**AFTER**:
<img width="1424" alt="Screenshot 2023-11-02 at 6 35 52 PM" src="https://github.com/opengovsg/credits-generator/assets/136435307/4bb3b281-e1b0-4b11-be87-0d4edcc9c71f">

